### PR TITLE
fix(视图): 修复空格导致Element宽度小于文字宽度。

### DIFF
--- a/tiny-whiteboard/src/utils/index.js
+++ b/tiny-whiteboard/src/utils/index.js
@@ -241,17 +241,12 @@ export const splitTextLines = text => {
 let textCheckEl = null
 export const getTextActWidth = (text, style) => {
   if (!textCheckEl) {
-    textCheckEl = document.createElement('div')
-    textCheckEl.style.position = 'fixed'
-    textCheckEl.style.left = '-99999px'
-    document.body.appendChild(textCheckEl)
+    textCheckEl = createCanvas(300,200)
+    textCheckEl.ctx.textBaseline = "middle"
   }
-  let { fontSize, fontFamily } = style
-  textCheckEl.innerText = text
-  textCheckEl.style.fontSize = fontSize + 'px'
-  textCheckEl.style.fontFamily = fontFamily
-  let { width } = textCheckEl.getBoundingClientRect()
-  return width
+  textCheckEl.ctx.font = `${style.fontSize}px ${style.fontFamily}`
+  textCheckEl.ctx.fillText(text, 0, 0)
+  return textCheckEl.ctx.measureText(text).width
 }
 
 // 计算固定宽度内能放下所有文字的最大字号
@@ -277,6 +272,10 @@ export const getWrapTextActWidth = element => {
     let width = getTextActWidth(textRow, element.style)
     if (width > maxWidth) {
       maxWidth = width
+    }
+    if (textCheckEl) {
+      const {canvas, ctx} = textCheckEl
+      ctx.clearRect(-canvas.width / 2, -canvas.width / 2, canvas.width * 2, canvas.width * 2)
     }
   })
   return maxWidth


### PR DESCRIPTION
测试文字：
```text
// 计算文本的实际渲染宽度
let textCheckEl = null
export const getTextActWidth = (text, style) => {
  if (!textCheckEl) {
    textCheckEl = document.createElement('div')
    textCheckEl.style.position = 'fixed'
    textCheckEl.style.left = '-99999px'
    document.body.appendChild(textCheckEl)
  }
  let { fontSize, fontFamily } =                                                        style
  textCheckEl.innerText = text
  textCheckEl.style.fontSize = fontSize + 'px'
  textCheckEl.style.fontFamily = fontFamily
  let { width } = textCheckEl.getBoundingClientRect()
  return width
}
```

![wanglin2 github io_tiny_whiteboard_demo_](https://github.com/wanglin2/tiny_whiteboard/assets/57182600/0a6d3353-5f35-4743-b29e-e16b7b2d74b5)

![localhost_3000_tiny_whiteboard_demo_](https://github.com/wanglin2/tiny_whiteboard/assets/57182600/368ff10f-7eae-4f27-9ab8-ad42bba5c74e)
